### PR TITLE
Fix pagination in admin selectors; default per-page = 10

### DIFF
--- a/admin/class-foyer-admin-channel.php
+++ b/admin/class-foyer-admin-channel.php
@@ -230,8 +230,8 @@ class Foyer_Admin_Channel {
                             <?php echo esc_html__( 'Rows per page', 'foyer' ); ?>
                         </label>
                         <select id="foyer_slides_table_per_page">
-                            <option value="10">10</option>
-                            <option value="20" selected>20</option>
+                            <option value="10" selected>10</option>
+                            <option value="20">20</option>
                             <option value="50">50</option>
                             <option value="100">100</option>
                         </select>
@@ -327,7 +327,10 @@ class Foyer_Admin_Channel {
                             }
 
                             function paginate(){
-                                var per = parseInt($perPage.val(), 10) || 20;
+                                var per = parseInt($perPage.val(), 10) || 10;
+                                // Reset to the full filtered set before slicing to avoid shrinking pool
+                                $rows.show();
+                                applyFilters();
                                 var visibleRows = $rows.filter(':visible');
                                 var total = visibleRows.length;
                                 var totalPages = Math.max(1, Math.ceil(total / per));

--- a/admin/class-foyer-admin-display.php
+++ b/admin/class-foyer-admin-display.php
@@ -104,12 +104,12 @@ class Foyer_Admin_Display {
             <label for="foyer_sched_selector_per_page" style="margin-left:auto;">
                 <?php echo esc_html__( 'Rows per page', 'foyer' ); ?>
             </label>
-            <select id="foyer_sched_selector_per_page">
-                <option value="10">10</option>
-                <option value="20" selected>20</option>
-                <option value="50">50</option>
-                <option value="100">100</option>
-            </select>
+                        <select id="foyer_sched_selector_per_page">
+                            <option value="10" selected>10</option>
+                            <option value="20">20</option>
+                            <option value="50">50</option>
+                            <option value="100">100</option>
+                        </select>
         </div>
         <table class="widefat fixed striped" id="foyer_sched_selector" style="margin-bottom:12px;">
             <thead>
@@ -297,7 +297,10 @@ class Foyer_Admin_Display {
                         updateSortIndicators();
                     }
                     function paginate(){
-                        var per = parseInt($perPage.val(), 10) || 20;
+                        var per = parseInt($perPage.val(), 10) || 10;
+                        // Reset to the full filtered set before slicing to avoid shrinking pool
+                        $rows.show();
+                        applyFilters();
                         var visibleRows = $rows.filter(':visible');
                         var total = visibleRows.length;
                         var totalPages = Math.max(1, Math.ceil(total / per));
@@ -593,8 +596,8 @@ class Foyer_Admin_Display {
                             <?php echo esc_html__( 'Rows per page', 'foyer' ); ?>
                         </label>
                         <select id="foyer_default_channels_per_page">
-                            <option value="10">10</option>
-                            <option value="20" selected>20</option>
+                            <option value="10" selected>10</option>
+                            <option value="20">20</option>
                             <option value="50">50</option>
                             <option value="100">100</option>
                         </select>
@@ -730,7 +733,10 @@ class Foyer_Admin_Display {
                             }
 
                             function paginate(){
-                                var per = parseInt($perPage.val(), 10) || 20;
+                                var per = parseInt($perPage.val(), 10) || 10;
+                                // Reset to the full filtered set before slicing to avoid shrinking pool
+                                $rows.show();
+                                applyFilters();
                                 var visibleRows = $rows.filter(':visible');
                                 var total = visibleRows.length;
                                 var totalPages = Math.max(1, Math.ceil(total / per));

--- a/admin/class-foyer-admin-scheduler.php
+++ b/admin/class-foyer-admin-scheduler.php
@@ -237,7 +237,7 @@ class Foyer_Admin_Scheduler {
         echo '<label for="foyer_template_selector_search" style="margin-right:6px;">' . esc_html__( 'Search', 'foyer' ) . '</label>';
         echo '<input type="search" id="foyer_template_selector_search" class="regular-text" placeholder="' . esc_attr__( 'Search by title or author…', 'foyer' ) . '" style="max-width:280px;" />';
         echo '<label for="foyer_template_selector_per_page" style="margin-left:auto;">' . esc_html__( 'Rows per page', 'foyer' ) . '</label>';
-        echo '<select id="foyer_template_selector_per_page"><option value="10">10</option><option value="20" selected>20</option><option value="50">50</option><option value="100">100</option></select>';
+        echo '<select id="foyer_template_selector_per_page"><option value="10" selected>10</option><option value="20">20</option><option value="50">50</option><option value="100">100</option></select>';
         echo '</div>';
         echo '<table class="widefat fixed striped" id="foyer_template_selector">';
         echo '<thead><tr>';
@@ -341,10 +341,11 @@ class Foyer_Admin_Scheduler {
                 }
                 function updateSortIndicators(){ var arrows={asc:'\u25B2',desc:'\u25BC'}; $selTable.find('thead th.foyer-sort-col .sort-ind').text(''); $selTable.find('thead th.foyer-sort-col[data-sort="'+sortKey+'"] .sort-ind').text(arrows[sortDir]||''); }
                 function sortRows(){ var $tbody=$selTable.find('tbody'); var vis=$rows.filter(':visible').get(); vis.sort(compareRows); $tbody.append(vis); $tbody.append($rows.filter(':hidden')); updateSortIndicators(); }
-                function paginate(){ var per=parseInt($perPage.val(),10)||20; var vis=$rows.filter(':visible'); var total=vis.length; var totalPages=Math.max(1, Math.ceil(total/per)); if(currentPage>totalPages) currentPage=totalPages; var start=(currentPage-1)*per; var end=start+per; vis.hide().slice(start,end).show(); $info.text(''+(total?start+1:0)+'-'+Math.min(end,total)+' / '+total); $prev.prop('disabled', currentPage<=1); $next.prop('disabled', currentPage>=totalPages); }
+                function paginate(){ var per=parseInt($perPage.val(),10)||10; $rows.show(); applyFilters(); var vis=$rows.filter(':visible'); var total=vis.length; var totalPages=Math.max(1, Math.ceil(total/per)); if(currentPage>totalPages) currentPage=totalPages; var start=(currentPage-1)*per; var end=start+per; vis.hide().slice(start,end).show(); $info.text(currentPage+' / '+totalPages); $prev.prop('disabled', currentPage<=1); $next.prop('disabled', currentPage>=totalPages); }
                 function refresh(){ $rows.show(); applyFilters(); sortRows(); paginate(); }
-                $search.on('input', refresh);
-                $selTable.find('thead').on('click','th.foyer-sort-col', function(){ var key=$(this).data('sort'); if(!key) return; if(key===sortKey){ sortDir=(sortDir==='asc')?'desc':'asc'; } else { sortKey=key; sortDir='asc'; } refresh(); });
+                $search.on('input', function(){ currentPage=1; refresh(); });
+                $perPage.on('change', function(){ currentPage=1; refresh(); });
+                $selTable.find('thead').on('click','th.foyer-sort-col', function(){ var key=$(this).data('sort'); if(!key) return; if(key===sortKey){ sortDir=(sortDir==='asc')?'desc':'asc'; } else { sortKey=key; sortDir='asc'; } currentPage=1; refresh(); });
                 $prev.on('click', function(){ currentPage=Math.max(1,currentPage-1); paginate(); });
                 $next.on('click', function(){ currentPage=currentPage+1; paginate(); });
                 refresh();


### PR DESCRIPTION
Recompute filtered set before slicing to avoid “1/1” bug Unify scheduler page info; reset page on search/sort/per-page Apply changes to Channel, Display, and Scheduler