### PR TITLE
fix: remove unimplemented Instagram slide format to prevent admin fatal

### DIFF
--- a/includes/class-foyer-slide-formats.php
+++ b/includes/class-foyer-slide-formats.php
@@ -47,6 +47,11 @@ class Foyer_Slide_Formats {
      * @since 1.7.6
      */
     static function add_instagram_slide_format( $slide_formats ) {
+        // Only register the Instagram format when its admin class is available.
+        // Prevents invalid callback errors when the class is not bundled/loaded.
+        if ( ! class_exists( 'Foyer_Admin_Slide_Format_Instagram' ) ) {
+            return $slide_formats;
+        }
 
         $slide_format_backgrounds = array( 'default', 'image' );
 

--- a/includes/class-foyer.php
+++ b/includes/class-foyer.php
@@ -66,8 +66,7 @@ class Foyer {
 		add_filter( 'foyer/slides/formats', array( 'Foyer_Slide_Formats', 'add_recent_posts_slide_format' ), 5 );
 			add_filter( 'foyer/slides/formats', array( 'Foyer_Slide_Formats', 'add_upcoming_productions_slide_format' ), 5 );
             add_filter( 'foyer/slides/formats', array( 'Foyer_Slide_Formats', 'add_pdf_slide_format' ), 5 );
-            // Additional formats
-            add_filter( 'foyer/slides/formats', array( 'Foyer_Slide_Formats', 'add_instagram_slide_format' ), 5 );
+            // Additional formats (Instagram removed)
 	}
 
 	/**


### PR DESCRIPTION
Remove Instagram format filter hookup in includes/class-foyer.php Guard Instagram format registration in includes/class-foyer-slide-formats.php with class_exists Resolves E_ERROR (TypeError) at admin/class-foyer-admin-slide.php:312 caused by invalid callback to missing Foyer_Admin_Slide_Format_Instagram class No impact to other slide formats; slide editor now loads without error